### PR TITLE
Refactor password validation to prevent UI lag by switching to timer-based validation

### DIFF
--- a/View/MainWindow.xaml.cs
+++ b/View/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Controls;
+using System.Windows.Threading;
 
 namespace RunTrack
 {
@@ -11,12 +12,18 @@ namespace RunTrack
     {
         public ResizeMode ResizeMode { get; set; }
         private MainModel _pageModel;
+        private DispatcherTimer passwordTimer;
 
         public MainWindow()
         {
             InitializeComponent();
 
             _pageModel = FindResource("pmodel") as MainModel ?? new();
+
+
+            passwordTimer = new DispatcherTimer();
+            passwordTimer.Interval = TimeSpan.FromMilliseconds(500); // 500 ms of inactivity before validation
+            passwordTimer.Tick += txtPasswort_PasswordTimerTick;
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
@@ -432,12 +439,24 @@ namespace RunTrack
                 }
             }
 
-            // ValidatePassword() takes between 223 and 589 milliseconds to execute. 
-            // This is primarily because BCrypt.Net.BCrypt.Verify, which is used for password verification, is a time-consuming operation.
-            // To keep the UI responsive, we run this in a background task.
-            // However, since ValidatePassword interacts with UI elements, we need to marshal the call back to the UI thread using Dispatcher.Invoke.
+            // Reset the timer
+            if (passwordTimer.IsEnabled)
+            {
+                passwordTimer.Stop();
+            }
 
-            Task.Run(() =>
+            // Start the timer again
+            passwordTimer.Start();
+        }
+
+        // ValidatePassword() takes between 223 and 589 milliseconds to execute. 
+        // This is primarily because BCrypt.Net.BCrypt.Verify, which is used for password verification, is a time-consuming operation.
+        private async void txtPasswort_PasswordTimerTick(object? sender, EventArgs e)
+        {
+            // Stop the timer to avoid multiple triggers
+            passwordTimer.Stop();
+
+            await Task.Run(() =>
             {
                 // ValidatePassword needs to be invoked on the UI thread because it accesses UI components.
                 Application.Current.Dispatcher.Invoke(() =>


### PR DESCRIPTION
### Description:
This PR addresses the performance issues caused by frequent calls to `Application.Current.Dispatcher.Invoke` in the previous password validation logic. The initial approach caused noticeable UI lag because the validation (which includes time-consuming BCrypt password checks) was being executed too frequently, directly on the UI thread.

### What has changed:
- Instead of running `ValidatePassword()` on every input, the process is now deferred by 500ms using a `DispatcherTimer`.
- If the user keeps typing, the timer resets, ensuring that the validation only happens when they stop typing for a short period.
- This prevents the UI from becoming unresponsive while still providing timely feedback after the user finishes entering the password.

### Apology:
During my initial tests, I didn't notice the lag because my computer processed the validation fast enough, so the issue wasn't obvious at first. However, further testing revealed the bug, and I've now implemented this timer-based solution to fix it. Everything seems to be working fine now, but I kindly ask you to take a look and confirm that this solution resolves the problem.

Thanks for reviewing!
